### PR TITLE
Add support for nested custom attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `README.md` with link to `pkg.go.dev` documentation
 - `README.md` with sending notification example
 
+### Fixed
+- `CustomAttributes` to `map[string]interface{}` to support multiple levels of custom attributes
+
 ## [0.1.0] - 2021-02-07
 ### Added
 - Basic API usage with error handling

--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ func main() {
 			{ExternalID: "some-id"},
         },
 		Content: "The notification inbox for your product. Get started in minutes.",
-		CustomAttributes: map[string]string{
-			"order_id": "123", 
-        },
+		CustomAttributes: map[string]interface{}{
+			"order": map[string]string{
+				"id": "1234567",
+				"title": "A title you can use in your templates",
+			},
+		},
 		ActionURL: "https://developer.magicbell.io",
 		Category:  "new_message",
 	})
@@ -73,7 +76,7 @@ func main() {
 		Email:      "hana@magicbell.io",
 		FirstName:  "Hana",
 		LastName:   "Mohan",
-		CustomAttributes: map[string]string{
+		CustomAttributes: map[string]interface{}{
 			"plan":              "enterprise",
 			"pricing_version":   "v10",
 			"preferred_pronoun": "She",

--- a/cmd/mbctl/cmd/notifications_create.go
+++ b/cmd/mbctl/cmd/notifications_create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -10,11 +11,44 @@ import (
 )
 
 type notificationsCreateOptions struct {
-	Title      string
-	Recipients []string
-	Content    string
-	ActionURL  string
-	Category   string
+	Title            string
+	Recipients       []string
+	Content          string
+	ActionURL        string
+	Category         string
+	CustomAttributes []string // Key=Value
+}
+
+func (o notificationsCreateOptions) getNotificationRecipients() (recipients []magicbell.NotificationRecipient) {
+	recipients = make([]magicbell.NotificationRecipient, len(notificationCreateOpts.Recipients))
+
+	for i, r := range notificationCreateOpts.Recipients {
+		if strings.ContainsRune(r, '@') {
+			recipients[i] = magicbell.NotificationRecipient{Email: r}
+		} else {
+			recipients[i] = magicbell.NotificationRecipient{ExternalID: r}
+		}
+	}
+
+	return
+}
+
+func (o notificationsCreateOptions) getCustomAttributes() magicbell.CustomAttributes {
+	if o.CustomAttributes == nil {
+		return nil
+	}
+
+	attrs := magicbell.CustomAttributes{}
+	for _, rawAttr := range o.CustomAttributes {
+		values := strings.SplitN(rawAttr, "=", 2)
+		if len(values) != 2 {
+			panic(fmt.Sprintf("expected '=' in custom attribute, got %s", rawAttr))
+		}
+
+		attrs[values[0]] = values[1]
+	}
+
+	return attrs
 }
 
 var (
@@ -23,25 +57,14 @@ var (
 		Aliases: []string{"send"},
 		Short:   "Send a notification to one or more users.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			recipients := make([]magicbell.NotificationRecipient, len(notificationCreateOpts.Recipients))
-
-			for i, r := range notificationCreateOpts.Recipients {
-				if strings.ContainsRune(r, '@') {
-					recipients[i] = magicbell.NotificationRecipient{Email: r}
-				} else {
-					recipients[i] = magicbell.NotificationRecipient{ExternalID: r}
-				}
-			}
-
 			notification, err := api.CreateNotificationC(cmd.Context(), magicbell.CreateNotificationRequest{
 				Title:            notificationCreateOpts.Title,
-				Recipients:       recipients,
+				Recipients:       notificationCreateOpts.getNotificationRecipients(),
 				Content:          notificationCreateOpts.Content,
-				CustomAttributes: nil,
+				CustomAttributes: notificationCreateOpts.getCustomAttributes(),
 				ActionURL:        notificationCreateOpts.ActionURL,
 				Category:         notificationCreateOpts.Category,
 			})
-
 			if err != nil {
 				return err
 			}
@@ -60,6 +83,7 @@ func init() {
 	notificationsCreateCmd.Flags().StringVar(&notificationCreateOpts.Content, "content", "", "The content of the notification")
 	notificationsCreateCmd.Flags().StringVar(&notificationCreateOpts.ActionURL, "action-url", "", "The URL to redirect to when clicking the notification")
 	notificationsCreateCmd.Flags().StringVar(&notificationCreateOpts.Category, "category", "", "The category of the notification")
+	notificationsCreateCmd.Flags().StringArrayVar(&notificationCreateOpts.CustomAttributes, "custom-attribute", nil, "A list of custom attributes in the Key=Value format")
 
 	_ = notificationsCreateCmd.MarkFlagRequired("title")
 	_ = notificationsCreateCmd.MarkFlagRequired("recipients")

--- a/custom_attributes.go
+++ b/custom_attributes.go
@@ -1,0 +1,5 @@
+package magicbell
+
+// CustomAttributes are any custom fields to map onto certain MagicBell resources.
+// Generally should contain other map[string]interface{} or map[string]string
+type CustomAttributes map[string]interface{}

--- a/notifications.go
+++ b/notifications.go
@@ -24,7 +24,7 @@ type CreateNotificationRequest struct {
 	// Content is the content of the notification to send
 	Content string `json:"content,omitempty"`
 	// CustomAttributes are a set of key-value pairs that you can attach to a notification
-	CustomAttributes map[string]string `json:"custom_attributes,omitempty"`
+	CustomAttributes CustomAttributes `json:"custom_attributes,omitempty"`
 	// ActionURL is a URL to redirect the user to when they click on the notification in MagicBell's embeddable notification center.
 	ActionURL string `json:"action_url,omitempty"`
 	// Category is the category this notification belongs to.

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -81,6 +81,12 @@ var (
 		}},
 		Content:  "Can I see a demo of your product?",
 		Category: "new_message",
+		CustomAttributes: map[string]interface{}{
+			"order": map[string]string{
+				"id":    "12345",
+				"title": "A title you can use in your templates",
+			},
+		},
 	}
 )
 

--- a/users.go
+++ b/users.go
@@ -22,7 +22,7 @@ type CreateUserRequest struct {
 	LastName string `json:"last_name,omitempty"`
 	// CustomAttributes are any customers attributes that you'd like to associate with the user.
 	// These custom attributes can later be utilized in MagicBell's web interface (when writing email templates for example).
-	CustomAttributes map[string]string `json:"custom_attributes,omitempty"`
+	CustomAttributes CustomAttributes `json:"custom_attributes,omitempty"`
 }
 
 // UpdateUserRequest is the set of data required to update an existing user in MagicBell.
@@ -40,7 +40,7 @@ type UpdateUserRequest struct {
 	LastName string `json:"last_name,omitempty"`
 	// CustomAttributes are any customers attributes that you'd like to associate with the user.
 	// These custom attributes can later be utilized in MagicBell's web interface (when writing email templates for example).
-	CustomAttributes map[string]string `json:"custom_attributes,omitempty"`
+	CustomAttributes CustomAttributes `json:"custom_attributes,omitempty"`
 }
 
 // User is MagicBell's representation of a user, uniquely identified by ID.
@@ -56,7 +56,7 @@ type User struct {
 	// LastName is the user's last name.
 	LastName string `json:"last_name"`
 	// CustomAttributes are any customers attributes that you'd like to associate with the user.
-	CustomAttributes map[string]string `json:"custom_attributes"`
+	CustomAttributes CustomAttributes `json:"custom_attributes"`
 }
 
 type createUserRequest struct {

--- a/users_test.go
+++ b/users_test.go
@@ -72,7 +72,7 @@ var (
 					Email:      "hana@magicbell.io",
 					FirstName:  "Hana",
 					LastName:   "Mohan",
-					CustomAttributes: map[string]string{
+					CustomAttributes: map[string]interface{}{
 						"plan":              "enterprise",
 						"pricing_version":   "v10",
 						"preferred_pronoun": "She",
@@ -143,7 +143,7 @@ var (
 		Email:      "hana@magicbell.io",
 		FirstName:  "Hana",
 		LastName:   "Mohan",
-		CustomAttributes: map[string]string{
+		CustomAttributes: map[string]interface{}{
 			"plan":              "enterprise",
 			"pricing_version":   "v10",
 			"preferred_pronoun": "She",


### PR DESCRIPTION
Update the `mbctl` CLI to support the `--custom-attribute` flag for create notification. And the library supports multiple levels of custom attributes.