### PR TITLE
Add user-agent and other headers by default to http requests

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,10 @@ builds:
     main: ./cmd/mbctl/main.go
     binary: mbctl
     ldflags:
-      - -s -w -X github.com/tizz98/magicbell-go/version.BuildVersion={{.Version}} -X github.com/tizz98/magicbell-go/version.BuildCommit={{.ShortCommit}}
+      - -s -w
+      - -X github.com/tizz98/magicbell-go/version.BuildVersion={{.Version}}
+      - -X github.com/tizz98/magicbell-go/version.BuildCommit={{.ShortCommit}}
+      - -X github.com/tizz98/magicbell-go/version.BuildName={{.Binary}}
 archives:
   - replacements:
       darwin: Darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2021-02-09
+### Added
+- `User-Agent` header to all HTTP requests
+- `Accept` header to all HTTP requests
+- `Content-Type` header to all HTTP requests
+- `version.BuildName` to be a string of either the library name or built binary name
+
+### Changed
+- `version.BuildVersion` to be a hardcoded version of the latest tagged version instead of `"dev"`
+
 ## [0.2.0] - 2021-02-08
 ### Added
 - `mbctl` CLI tool with `config init`, `notifications create`, and `users generate-hmac` commands 

--- a/api.go
+++ b/api.go
@@ -9,6 +9,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/tizz98/magicbell-go/version"
 )
 
 const (
@@ -71,6 +73,9 @@ func (c *Config) withBaseURL(url string) Config {
 func (a *API) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.Header.Set(apiKeyHeader, a.config.APIKey)
 	r.Header.Set(apiSecretHeader, a.config.APISecret)
+	r.Header.Set("User-Agent", fmt.Sprintf("%s/%s", version.BuildName, version.BuildVersion))
+	r.Header.Set("Accept", "application/json")
+	r.Header.Set("Content-Type", "application/json")
 	return http.DefaultTransport.RoundTrip(r)
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,10 +1,13 @@
 package version
 
 var (
-	// BuildVersion is the git tag of the built binary.
-	// If using this as a library, it will always be "dev".
-	BuildVersion = "dev"
+	// BuildVersion is the git tag of this library.
+	BuildVersion = "v0.3.0"
 	// BuildCommit is the short git commit of the built binary.
 	// If using this as a library, it will always be "dev".
 	BuildCommit = "dev"
+	// BuildName is the name of the build. If using as a library, this
+	// will always be magicbell-go. But can be overridden for binary builds,
+	// for example the mbctl CLI tool.
+	BuildName = "magicbell-go"
 )


### PR DESCRIPTION
## Proposed Changes

- `User-Agent` header to all HTTP requests
- `Accept` header to all HTTP requests
- `Content-Type` header to all HTTP requests
- `version.BuildName` to be a string of either the library name or built binary name
- `version.BuildVersion` to be a hardcoded version of the latest tagged version instead of `"dev"`

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Tests covering new or updated code
- [x] Documentation for exported functions and structs
- [x] `README.md` updated for CLI or other notable features
